### PR TITLE
fix(lib/test): stack traces when res.name is Error, not string

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -261,7 +261,8 @@ Test.prototype._assert = function assert(ok, opts) {
     this._ok = !!(this._ok && ok);
 
     if (!ok && !res.todo) {
-        res.error = defined(extra.error, opts.error, new Error(res.name));
+        var anError = res.name instanceof Error ? res.name : new Error(res.name);
+        res.error = defined(extra.error, opts.error, anError);
     }
 
     if (!ok) {


### PR DESCRIPTION
When executing tests, the res.name property
(as constructed in the ./lib/test.js#_assert method)
is actually not a string but the error that was thrown.
This (assuming edge case) combined with
extra.error and opts.error both being falsy ends up
producing this situation where feeding res.name into
the Error constructor makes the original error's stack
trace disappear and only it's message remains with the
newly constructed Error instance holding a completely
generic stack trace that's internal to tape's source code
(and therefore not much use when a test is failing due to
some code is throwing exceptions instead of failing an
assertion).

Signed-off-by: Peter Somogyvari <peter.metz@unarin.com>