### PR TITLE
[Dev Deps] remove unused `intl-fallback-symbol`, `is-core-module`

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,8 +54,6 @@
 		"es-value-fixtures": "^1.4.2",
 		"eslint": "=8.8.0",
 		"falafel": "^2.2.5",
-		"intl-fallback-symbol": "^1.0.0",
-		"is-core-module": "^2.13.1",
 		"jackspeak": "=2.1.1",
 		"js-yaml": "^3.14.0",
 		"npm-run-posix-or-windows": "^2.0.2",


### PR DESCRIPTION
is-core-module is nowhere used